### PR TITLE
Add limit parameter to `exoplanets`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,8 @@ Title: Access NASA's Exoplanet Archive Data
 Version: 0.2.0.9000
 Authors@R: c(
   person("Tyler", "Littlefield", email = "tylerlittlefield@hey.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6020-1125")),
-  person("Maëlle", "Salmon", role = c("ctb", "rev")))
+  person("Maëlle", "Salmon", role = c("ctb", "rev")),
+  person("Mathida", "Chuk", role = c("ctb")))
 Description: The goal of exoplanets is to provide access to
     NASA's Exoplanet Archive TAP Service. For more information regarding
     the API please read the documentation

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # exoplanets (development version)
 
 * Added `forget_exoplanets` to clear the `exoplanets` cache.
-* Added pacakge level documentation with `usethis::use_package_doc`.
+* Added package level documentation with `usethis::use_package_doc`.
+* Added `limit` parameter to `exoplanets`.
 
 # exoplanets 0.2.0
 

--- a/R/exoplanets.R
+++ b/R/exoplanets.R
@@ -1,10 +1,11 @@
-parse_url <- function(table, columns, format) {
+parse_url <- function(table, columns, limit, format) {
   if (!format %in% FORMATS) {
     stop("Expected formats are:", paste0("\n* ", FORMATS), call. = FALSE)
   }
 
   columns <- paste0(columns, collapse = ",")
-  query <- paste0("select+", columns, "+from+", table, "&format=", format)
+  q_lim <- ifelse(limit == Inf, "", paste0("+top+", limit))
+  query <- paste0("select+", columns, "+from+", table, q_lim, "&format=", format)
   url <- paste0(BASE, query)
   type <- switch (format,
     "csv" = "text/csv",
@@ -16,13 +17,14 @@ parse_url <- function(table, columns, format) {
     query = query,
     table = table,
     columns = columns,
+    limit = limit,
     format = format,
     type = type
   )
 }
 
-fetch_data <- function(table, columns, format, progress) {
-  url <- parse_url(table, columns, format)
+fetch_data <- function(table, columns, limit, format, progress) {
+  url <- parse_url(table, columns, limit, format)
   cli::cat_bullet(BASE, cli::style_bold(url$query))
 
   if (progress) {
@@ -53,6 +55,7 @@ fetch_data <- function(table, columns, format, progress) {
 #'
 #' @param table A table name, see `tableinfo`
 #' @param columns A vector of valid column names, by default will return all default columns, see `tableinfo`
+#' @param limit Number of rows to return. Defaulted to `Inf`, which returns all data in table.
 #' @param format Desired format, either csv, tsv, or json
 #' @param progress Whether or not to display the progress of the request
 #'
@@ -78,7 +81,7 @@ fetch_data <- function(table, columns, format, progress) {
 #' }
 #'
 #' @export
-exoplanets <- function(table, columns = NULL, format = "csv", progress = TRUE) {
+exoplanets <- function(table, columns = NULL, limit = Inf, format = "csv", progress = TRUE) {
   if (is.null(columns)) columns <- "*"
-  fetch_data(table, columns, format, progress)
+  fetch_data(table, columns, limit, format, progress)
 }

--- a/R/exoplanets.R
+++ b/R/exoplanets.R
@@ -73,6 +73,9 @@ fetch_data <- function(table, columns, limit, format, progress) {
 #'   # request the planet name and discovery method from the `ps` table
 #'   exoplanets("ps", c("pl_name", "discoverymethod"))
 #'
+#'   # request the first 5 rows from the `keplernames` table
+#'   exoplanets("keplernames", "*", limit = 5)
+#'
 #'   # request in json format (returns list)
 #'   exoplanets("ps", c("pl_name", "discoverymethod"), format = "json")
 #'

--- a/README.Rmd
+++ b/README.Rmd
@@ -118,6 +118,12 @@ If you wish, you can select only the columns you need:
 exoplanets("ps", c("pl_name", "hostname"), progress = FALSE)
 ```
 
+You can also specify the number of rows returned using `limit`:
+
+```{r}
+exoplanets("keplernames", columns = "*", limit = 5, progress = FALSE)
+```
+
 Information on the tables and columns available can be found with:
 
 ```{r}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Service](https://exoplanetarchive.ipac.caltech.edu/docs/TAP/usingTAP.html).
 The functionality of this package is minimal and is simply an R
 interface to access exoplanet data.
 
-<img src="man/figures/README-unnamed-chunk-2-1.png" title="Exoplanets color coded by discovery method" alt="Exoplanets color coded by discovery method" width="100%" />
+<img src="man/figures/README-unnamed-chunk-2-1.png" width="100%" />
 
 ## Installation
 
@@ -91,6 +91,29 @@ exoplanets("ps", c("pl_name", "hostname"), progress = FALSE)
 #>  9 HD 167042 b  HD 167042 
 #> 10 HD 210702 b  HD 210702 
 #> # … with 29,388 more rows
+```
+
+You can also specify the number of rows returned using `limit`:
+
+``` r
+exoplanets("keplernames", columns = "*", limit = 5, progress = FALSE)
+#> • https://exoplanetarchive.ipac.caltech.edu/TAP/sync?query=select+*+from+keplernames+top+5&format=csv
+#> 
+#> ── Column specification ────────────────────────────────────────────────────────
+#> cols(
+#>   kepid = col_double(),
+#>   koi_name = col_character(),
+#>   kepler_name = col_character(),
+#>   pl_name = col_character()
+#> )
+#> # A tibble: 5 x 4
+#>     kepid koi_name  kepler_name   pl_name      
+#>     <dbl> <chr>     <chr>         <chr>        
+#> 1 7515212 K00679.02 Kepler-212 b  Kepler-212 b 
+#> 2 8210018 K02762.01 Kepler-1341 b Kepler-1341 b
+#> 3 9008737 K02768.01 Kepler-404 b  Kepler-404 b 
+#> 4 4833421 K00232.05 Kepler-122 f  Kepler-122 f 
+#> 5 9963524 K00720.02 Kepler-221 d  Kepler-221 d
 ```
 
 Information on the tables and columns available can be found with:

--- a/man/exoplanets-package.Rd
+++ b/man/exoplanets-package.Rd
@@ -27,6 +27,7 @@ Useful links:
 Other contributors:
 \itemize{
   \item Maëlle Salmon [contributor, reviewer]
+  \item Mathida Chuk [contributor]
 }
 
 }

--- a/man/exoplanets.Rd
+++ b/man/exoplanets.Rd
@@ -7,12 +7,14 @@
 \url{https://exoplanetarchive.ipac.caltech.edu/}
 }
 \usage{
-exoplanets(table, columns = NULL, format = "csv", progress = TRUE)
+exoplanets(table, columns = NULL, limit = Inf, format = "csv", progress = TRUE)
 }
 \arguments{
 \item{table}{A table name, see `tableinfo`}
 
 \item{columns}{A vector of valid column names, by default will return all default columns, see `tableinfo`}
+
+\item{limit}{Number of rows to return. Defaulted to `Inf`, which returns all data in table.}
 
 \item{format}{Desired format, either csv, tsv, or json}
 

--- a/man/exoplanets.Rd
+++ b/man/exoplanets.Rd
@@ -44,6 +44,9 @@ if (interactive()) {
   # request the planet name and discovery method from the `ps` table
   exoplanets("ps", c("pl_name", "discoverymethod"))
 
+  # request the first 5 rows from the `keplernames` table
+  exoplanets("keplernames", "*", limit = 5)
+
   # request in json format (returns list)
   exoplanets("ps", c("pl_name", "discoverymethod"), format = "json")
 

--- a/tests/testthat/test-exoplanets.R
+++ b/tests/testthat/test-exoplanets.R
@@ -18,28 +18,31 @@ test_that("parse_url works", {
   # test errors when incorrect format given
   expect_snapshot_error(parse_url("ps", "*", format = "sqlite"))
 
-  # test csv url parsing
-  x <- parse_url("ps", "*", "csv")
+  # test csv url parsing & limit = 10
+  x <- parse_url("ps", "*", 10, "csv")
   expect_equal(x$table, "ps")
   expect_equal(x$columns, "*")
+  expect_equal(x$limit, 10)
   expect_equal(x$format, "csv")
   expect_equal(x$type, "text/csv")
-  expect_equal(x$query, "select+*+from+ps&format=csv")
-  expect_equal(x$url, "https://exoplanetarchive.ipac.caltech.edu/TAP/sync?query=select+*+from+ps&format=csv")
+  expect_equal(x$query, "select+*+from+ps+top+10&format=csv")
+  expect_equal(x$url, "https://exoplanetarchive.ipac.caltech.edu/TAP/sync?query=select+*+from+ps+top+10&format=csv")
 
-  # test json url parsing
-  x <- parse_url("k2names", c("epic_id", "k2_name"), "json")
+  # test json url parsing & limit = 10
+  x <- parse_url("k2names", c("epic_id", "k2_name"), 10, "json")
   expect_equal(x$table, "k2names")
   expect_equal(x$columns, "epic_id,k2_name")
+  expect_equal(x$limit, 10)
   expect_equal(x$format, "json")
   expect_equal(x$type, "application/json")
-  expect_equal(x$query, "select+epic_id,k2_name+from+k2names&format=json")
-  expect_equal(x$url, "https://exoplanetarchive.ipac.caltech.edu/TAP/sync?query=select+epic_id,k2_name+from+k2names&format=json")
+  expect_equal(x$query, "select+epic_id,k2_name+from+k2names+top+10&format=json")
+  expect_equal(x$url, "https://exoplanetarchive.ipac.caltech.edu/TAP/sync?query=select+epic_id,k2_name+from+k2names+top+10&format=json")
 
-  # test tsv url parsing
-  x <- parse_url("k2names", c("epic_id", "k2_name"), "tsv")
+  # test tsv url parsing & limit = Inf
+  x <- parse_url("k2names", c("epic_id", "k2_name"), Inf, "tsv")
   expect_equal(x$table, "k2names")
   expect_equal(x$columns, "epic_id,k2_name")
+  expect_equal(x$limit, Inf)
   expect_equal(x$format, "tsv")
   expect_equal(x$type, "text/tab-separated-values")
   expect_equal(x$query, "select+epic_id,k2_name+from+k2names&format=tsv")


### PR DESCRIPTION
## Description
This PR adds `limit` parameter to `exoplanets()`.

## Related Issue
Addresses #7. 

## Example
```
# returns all rows by default.
exoplanets("keplernames", columns = "*", progress = FALSE)

# returns first _n_ matches if specified
exoplanets("keplernames", columns = "*", limit = 5, progress = FALSE)
```
